### PR TITLE
Removed secondary download and print buttons

### DIFF
--- a/asset/vendor/pdf.js/web/viewer.html
+++ b/asset/vendor/pdf.js/web/viewer.html
@@ -155,18 +155,6 @@ See https://github.com/adobe-type-tools/cmap-resources
 
         <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
           <div id="secondaryToolbarButtonContainer">
-            <button id="secondaryOpenFile" class="secondaryToolbarButton visibleLargeView" title="Open File" tabindex="51" data-l10n-id="open_file">
-              <span data-l10n-id="open_file_label">Open</span>
-            </button>
-
-            <button id="secondaryPrint" class="secondaryToolbarButton visibleMediumView" title="Print" tabindex="52" data-l10n-id="print">
-              <span data-l10n-id="print_label">Print</span>
-            </button>
-
-            <button id="secondaryDownload" class="secondaryToolbarButton visibleMediumView" title="Save" tabindex="53" data-l10n-id="save">
-              <span data-l10n-id="save_label">Save</span>
-            </button>
-
             <div class="horizontalToolbarSeparator visibleLargeView"></div>
 
             <button id="presentationMode" class="secondaryToolbarButton" title="Switch to Presentation Mode" tabindex="54" data-l10n-id="presentation_mode">


### PR DESCRIPTION
Hello,

The secondary toolbar contains problematic buttons (Namely, download and print).

This patch removes them from pdfjs, easily.