### PR TITLE
Respect media order

### DIFF
--- a/src/Controller/Site/ViewerController.php
+++ b/src/Controller/Site/ViewerController.php
@@ -18,7 +18,9 @@ class ViewerController extends AbstractActionController
 
     public function mediaSelectorAction()
     {
-        $medias = $this->api()->search('media', $this->params()->fromQuery())->getContent();
+        $item_id = $this->params()->fromQuery()['item_id'];
+        $item = $this->api()->read('items', $item_id)->getContent();
+        $medias = $item->media();
 
         $view = new ViewModel();
         $view->setTerminal(true);


### PR DESCRIPTION
The `search` api endpoint sorts by `created`, which causes OctopusViewer to not respect the media order actually configured in the Edit Item page

# Testing

1. Upload a bunch of files to an item
2. Save
3. Reorder those files
4. Save
5. Go to item page with OctopusViewer

Before: Item order reflects upload order
After: Item order reflects order in Item Media page