### PR TITLE
Filename Fallback

### DIFF
--- a/documentation/configuration.rst
+++ b/documentation/configuration.rst
@@ -171,3 +171,6 @@ Use global setting
 
 No text
     Display no text. Only the thumbnail will be visible.
+
+Filename
+    Displays the filename

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -82,6 +82,7 @@ class ConfigForm extends Form
                 'value_options' => [
                     'untitled' => '[Untitled]', // @translate
                     'no_text' => 'No text', // @translate
+                    'filename' => 'Filename', // @translate
                 ],
             ],
             'attributes' => [

--- a/view/octopus-viewer/site/viewer/media-selector.phtml
+++ b/view/octopus-viewer/site/viewer/media-selector.phtml
@@ -14,7 +14,8 @@ if ($defaultMediaTitle === 'no_text') {
 <?php foreach ($medias as $media): ?>
     <?php
     $displayTitle = $media->displayTitle('');
-    $title = $displayTitle !== '' && $displayTitle !== $media->source() ? $displayTitle : $defaultTitle;
+    $defaultTitleForThisEntry = $defaultMediaTitle === 'filename' ? ($media->source() ?? '') : $defaultTitle;
+    $title = $displayTitle !== '' && $displayTitle !== $media->source() ? $displayTitle : $defaultTitleForThisEntry;
     ?>
     <a
         class="octopusviewer-media-selector-element"


### PR DESCRIPTION
Adds the ability to fallback on the filename as a default title option

<img width="275" alt="image" src="https://github.com/user-attachments/assets/44a459ca-1579-45bf-b16f-29810d3303a0">
